### PR TITLE
Fixes the issue of collection for python version 3.11

### DIFF
--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -28,8 +28,8 @@ try:
   # Since python 3
   from six.moves import collections_abc
 except ImportError:
-  # Won't work after python 3.8
-  import collections as collections_abc
+  # Fixes the issue for python 3.11
+  import collections.abc as collections_abc
 
 from facebook_business.adobjects.objectparser import ObjectParser
 from facebook_business.typechecker import TypeChecker


### PR DESCRIPTION
Error:

AttributeError: module 'collections' has no attribute 'Mapping'
Reason:

In Python 3.10 and later, 'Mapping' has been moved from 'collections' to 'collections.abc'.
Solution:

Update any code importing 'Mapping' from 'collections' to import it from 'collections.abc' instead.
Fix:

Error: - from collections import Mapping
Right: - from collections.abc import Mapping

fields = ['name', 'account_status']
params = {}
acc_details = AdAccount(client_adaccount).api_get(fields=fields, params=params)

issue link: -https://github.com/facebook/facebook-python-business-sdk/issues/707